### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project implements an optimized read-only MCP server for the Notion API, focusing on performance and efficiency for AI assistants to query and retrieve Notion content.
 
+<a href="https://glama.ai/mcp/servers/@Taewoong1378/notion-readonly-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Taewoong1378/notion-readonly-mcp-server/badge" alt="Notion ReadOnly Server MCP server" />
+</a>
+
 ## Key Improvements
 
 - **Read-Only Design**: Focused exclusively on data retrieval operations, ensuring safe access to Notion content.


### PR DESCRIPTION
This PR adds a badge for the [Notion ReadOnly MCP Server](https://glama.ai/mcp/servers/@Taewoong1378/notion-readonly-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Taewoong1378/notion-readonly-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Taewoong1378/notion-readonly-mcp-server/badge" alt="Notion ReadOnly Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.